### PR TITLE
Add command line option to specify Container image

### DIFF
--- a/run-testcases
+++ b/run-testcases
@@ -35,6 +35,7 @@ parser.add_argument("-v", "--verbose", action = "count", default = 0, help = "In
 parser.add_argument("-c", "--client-id", metavar = "client_id", required = True, help = "Client ID to use for the labwork client. Mandatory argument.")
 parser.add_argument("-a", "--assignment", metavar = "assignment_name", required = True, help = "Assignment name to execute. Mandatory argument.")
 parser.add_argument("-e", "--docker-executable", metavar = "executable", default = "docker", help = "Specify an executable to run the containers. Useful if e.g. podman should be used instead of docker.")
+parser.add_argument("-i", "--docker-image", metavar = "docker_image", default = "ghcr.io/johndoe31415/labwork-docker:master", help = "Specify a custom container image, e.g. a locally built one.")
 parser.add_argument("-t", "--timeout-secs", metavar = "secs", default = 30.0, help = "Terminate clients after this amoung of time, in seconds. Defaults to %(default).1f seconds.")
 parser.add_argument("submission_file", metavar = "filename", help = "Submission .tar.gz archive")
 args = parser.parse_args(sys.argv[1:])
@@ -61,7 +62,7 @@ class TestcaseRunner():
 		cmd = [ self._args.docker_executable, "create" ]
 		if not self._args.no_network_isolation:
 			cmd += [ "--network", "nonat", "--dns", "0.0.0.0", "--dns-search", "localdomain" ]
-		cmd += [ "labwork", "/labwork/labwork-execute", self._args.server_uri, self._args.client_id, self._args.assignment ]
+		cmd += [ self._args.docker_image, "/labwork/labwork-execute", self._args.server_uri, self._args.client_id, self._args.assignment ]
 		container_id = subprocess.check_output(cmd).decode("ascii").rstrip("\r\n")
 
 		subprocess.check_call([ self._args.docker_executable, "cp", submission_file, "%s:/labwork/labwork.tar.gz" % (container_id) ], stdout = subprocess.DEVNULL)


### PR DESCRIPTION
This PR adds a command line flag, to specify a custom container image. By default, the container image provided through GitHub is used.