### PR TITLE
add cargo to the container to enable solutions written in Rust

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get install --yes git build-essential libcjson-dev openjdk-17-jdk libbcprov-java libgoogle-gson-java libssl-dev gcc g++ libbotan-2-dev nlohmann-json3-dev python3 python3-pip rustc && rm -fr /var/cache/apt/* /var/lib/apt/lists/*
+RUN apt-get update && apt-get install --yes git build-essential libcjson-dev openjdk-17-jdk libbcprov-java libgoogle-gson-java libssl-dev gcc g++ libbotan-2-dev nlohmann-json3-dev python3 python3-pip rustc cargo && rm -fr /var/cache/apt/* /var/lib/apt/lists/*
 RUN pip3 install cryptography requests
 
 RUN mkdir /labwork


### PR DESCRIPTION
Rust may be used for labwork solutions, but the docker container does not have `cargo` installed. `cargo` is the defacto default for developing Rust. It is theoretically possible to build and compile `cargo` projects with just `rustc`, but that would be unneeded extra work.

I have tested this by using a small rust project (just a hello world pretty much) as a labwork solution. 

As a heads up: Cargo normally downloads dependencies from crates.io, which won't work in an environment without connectivity. We can work around this by vendoring the dependencies in: see [this](https://stackoverflow.com/questions/32267233/how-to-build-a-project-using-cargo-in-an-offline-environment) stackoverflow thread for more info.