### PR TITLE
Fix go installation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,5 +4,5 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install --yes git build-essential pkg-config libcjson-dev openjdk-17-jdk libbcprov-java libgoogle-gson-java libssl-dev gcc g++ libbotan-2-dev nlohmann-json3-dev python3 python3-pip rustc cargo iputils-ping telnet wget && rm -fr /var/cache/apt/* /var/lib/apt/lists/*
 RUN pip3 install --break-system-packages cryptography requests
 
-RUN wget -qO- https://go.dev/VERSION?m=text | head -n 1 | xargs -I {} wget https://go.dev/dl/{}.linux-amd64.tar.gz && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.23.2.linux-amd64.tar.gz && rm -rf go1.23.2.linux-amd64.tar.gz && apt-get purge -y wget
+RUN GO_VERSION=$(wget -qO- https://go.dev/VERSION?m=text | head -n 1) && wget https://go.dev/dl/${GO_VERSION}.linux-amd64.tar.gz && rm -rf /usr/local/go && tar -C /usr/local -xzf ${GO_VERSION}.linux-amd64.tar.gz && rm -rf ${GO_VERSION}.linux-amd64.tar.gz
 ENV PATH $PATH:/usr/local/go/bin

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get install --yes git build-essential pkg-config libcjson-dev openjdk-17-jdk libbcprov-java libgoogle-gson-java libssl-dev gcc g++ libbotan-2-dev nlohmann-json3-dev python3 python3-pip rustc cargo iputils-ping telnet golang-go && rm -fr /var/cache/apt/* /var/lib/apt/lists/*
+RUN apt-get update && apt-get install --yes git build-essential pkg-config libcjson-dev openjdk-17-jdk libbcprov-java libgoogle-gson-java libssl-dev gcc g++ libbotan-2-dev nlohmann-json3-dev python3 python3-pip rustc cargo iputils-ping telnet wget && rm -fr /var/cache/apt/* /var/lib/apt/lists/*
 RUN pip3 install --break-system-packages cryptography requests
+
+RUN wget -qO- https://go.dev/VERSION?m=text | head -n 1 | xargs -I {} wget https://go.dev/dl/{}.linux-amd64.tar.gz && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.23.2.linux-amd64.tar.gz && rm -rf go1.23.2.linux-amd64.tar.gz && apt-get purge -y wget
+ENV PATH $PATH:/usr/local/go/bin


### PR DESCRIPTION
The official Golang documentation suggests not doing the installation via the package manager, but instead downloading the tarball and extracting it yourself.

The installation via the package manager ensures that the Golang version of the individual project is installed as soon as it is used, depending on the required version.

The fix installs the latest, most stable version of Golang according to the procedure in the documentation.

https://go.dev/doc/install