### PR TITLE
vendor essential rust dependencies in the docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,3 +3,5 @@ FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install --yes git build-essential pkg-config libcjson-dev openjdk-17-jdk libbcprov-java libgoogle-gson-java libssl-dev gcc g++ libbotan-2-dev nlohmann-json3-dev python3 python3-pip rustc cargo iputils-ping telnet golang-go && rm -fr /var/cache/apt/* /var/lib/apt/lists/*
 RUN pip3 install --break-system-packages cryptography requests
+COPY rust /rust
+RUN cd /rust && cargo vendor

--- a/docker/rust/Cargo.toml
+++ b/docker/rust/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "vendorhelper"
+
+[dependencies]
+anyhow = "1.0"
+base64 = "0.22"
+getopts = "0.2"
+openssl = "0.10"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+threadpool = "1.8"


### PR DESCRIPTION
You had requested that the rust dependencies be standardized inside the docker image. This PR achieves this by providing the sources of the dependencies in `/rust/vendor`. Users can make a link to this directory in their `build` script to use the vendored dependencies in their projects.

For now, the following rust crates are vendored, along with the ones they depend on:

- `base64` encoding/decoding to and from the base64 format
- `openssl` binding to use openssl from rust
- `serde` (de)serialization of datastructures from various formats (generc implementation)
- `serde_json` working with JSON from rust
- `getopts` simple CLI flags like `--help`
- `threadpool` let a number of threads perform jobs synchroniously
- `anyhow` makes it a bit easier to work with `Result` types

We have tested this change and it works for us.