### PR TITLE
Installing newer version of gradle and manually installing required plugin via workaround

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get install --yes git build-essential pkg-config libcjson-dev openjdk-17-jdk gradle libbcprov-java libgoogle-gson-java libssl-dev gcc g++ libbotan-2-dev nlohmann-json3-dev python3 python3-pip rustc cargo iputils-ping telnet wget && rm -fr /var/cache/apt/* /var/lib/apt/lists/*
+RUN apt-get update && apt-get install --yes curl wget zip git build-essential pkg-config libcjson-dev openjdk-17-jdk libbcprov-java libgoogle-gson-java libguava-java libssl-dev gcc g++ libbotan-2-dev nlohmann-json3-dev python3 python3-pip rustc cargo iputils-ping telnet wget && rm -fr /var/cache/apt/* /var/lib/apt/lists/*
 RUN pip3 install --break-system-packages cryptography requests
 
 RUN GO_VERSION=$(wget -qO- https://go.dev/VERSION?m=text | head -n 1) && wget https://go.dev/dl/${GO_VERSION}.linux-amd64.tar.gz && rm -rf /usr/local/go && tar -C /usr/local -xzf ${GO_VERSION}.linux-amd64.tar.gz && rm -rf ${GO_VERSION}.linux-amd64.tar.gz
@@ -9,3 +9,13 @@ ENV PATH $PATH:/usr/local/go/bin
 
 COPY rust /rust
 RUN cd /rust && cargo vendor
+
+# Install SDKMAN
+RUN curl -s "https://get.sdkman.io" | bash
+# Install Gradle
+RUN bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && sdk install gradle"
+
+# Installing gradle plugin dependecy...
+COPY gradle /gradle
+WORKDIR /gradle
+RUN bash -c "$HOME/.sdkman/candidates/gradle/current/bin/gradle --no-daemon dependencies"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,14 +10,15 @@ ENV PATH $PATH:/usr/local/go/bin
 COPY rust /rust
 RUN cd /rust && cargo vendor
 
-# Install SDKMAN
-RUN curl -s "https://get.sdkman.io" | bash
-# Install Gradle
-RUN bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && sdk install gradle"
+# Downloading and installing gradle
+RUN curl -L https://services.gradle.org/distributions/gradle-8.10.2-bin.zip -o /tmp/gradle-8.10.2.zip
+RUN unzip /tmp/gradle-8.10.2.zip -d /usr/local/ && mv /usr/local/gradle-8.10.2 /usr/local/gradle
+ENV PATH $PATH:/usr/local/gradle/bin
 
-# Installing gradle plugin dependecy...
+# Installing gradle plugin dependecy via workaround...
 COPY gradle /gradle
 WORKDIR /gradle
-RUN bash -c "$HOME/.sdkman/candidates/gradle/current/bin/gradle --no-daemon dependencies"
+RUN bash -c "/usr/local/gradle/bin/gradle --no-daemon dependencies"
+RUN rm -rf /gradle && rm -f /tmp/gradle-8.10.2.zip
 
 WORKDIR /

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,3 +19,5 @@ RUN bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && sdk install gradle"
 COPY gradle /gradle
 WORKDIR /gradle
 RUN bash -c "$HOME/.sdkman/candidates/gradle/current/bin/gradle --no-daemon dependencies"
+
+WORKDIR /

--- a/docker/gradle/gradle.properties
+++ b/docker/gradle/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.parallel=true
+org.gradle.caching=true
+

--- a/docker/gradle/settings.gradle.kts
+++ b/docker/gradle/settings.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+}
+rootProject.name = "kauma"


### PR DESCRIPTION
Removed apt-package gradle and added curl, wget, zip and libguava-java
Installing gradle via sdkman instead
Installing gradle plugin via workaround (that's what the gradle folder is for)