### PR TITLE
Remove dangling /rust directory

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,11 +4,13 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install --yes curl wget zip git build-essential pkg-config libcjson-dev openjdk-17-jdk libbcprov-java libgoogle-gson-java libguava-java libssl-dev gcc g++ libbotan-2-dev nlohmann-json3-dev python3 python3-pip rustc cargo iputils-ping telnet wget && rm -fr /var/cache/apt/* /var/lib/apt/lists/*
 RUN pip3 install --break-system-packages cryptography requests
 
+# Install latest Go environment
 RUN GO_VERSION=$(wget -qO- https://go.dev/VERSION?m=text | head -n 1) && wget https://go.dev/dl/${GO_VERSION}.linux-amd64.tar.gz && rm -rf /usr/local/go && tar -C /usr/local -xzf ${GO_VERSION}.linux-amd64.tar.gz && rm -rf ${GO_VERSION}.linux-amd64.tar.gz
 ENV PATH $PATH:/usr/local/go/bin
 
-COPY rust /rust
-RUN cd /rust && cargo vendor
+# Install Rust and vendor in dependencies
+COPY rust /opt/rust
+RUN cd /opt/rust && cargo vendor
 
 # Downloading and installing gradle
 RUN curl -L https://services.gradle.org/distributions/gradle-8.10.2-bin.zip -o /tmp/gradle-8.10.2.zip


### PR DESCRIPTION
We need the directory /rust only during container provisioning, after which it becomes obsolete. Remove it after dependencies have been vendored in.