### PR TITLE
Added dependencies for rust for edf

### DIFF
--- a/docker/rust/Cargo.toml
+++ b/docker/rust/Cargo.toml
@@ -9,3 +9,5 @@ openssl = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 threadpool = "1.8"
+num = "0.4"
+rand = "0.8"


### PR DESCRIPTION
Added dependencies for rust needed for the edf implementation:

- num: Needed for BigInt and Traits to compute  g = (h ** (((q ** d) - 1) / 3) - 1) % f
- rand: Needed for computing a random polynomial