### PR TITLE
add system packages required for rust crate rug

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive
 RUN useradd -m -s /bin/bash kartfire
 
-RUN apt-get update && apt-get install --yes curl wget zip git build-essential pkg-config libcjson-dev openjdk-21-jdk libbcprov-java libgoogle-gson-java libguava-java libssl-dev gcc g++ libbotan-2-dev nlohmann-json3-dev libgmp-dev python3 python3-pip iputils-ping telnet wget rustup && rm -fr /var/cache/apt/* /var/lib/apt/lists/*
+RUN apt-get update && apt-get install --yes curl wget zip git build-essential pkg-config libcjson-dev openjdk-21-jdk libbcprov-java libgoogle-gson-java libguava-java libssl-dev gcc g++ libbotan-2-dev nlohmann-json3-dev libgmp-dev python3 python3-pip iputils-ping telnet wget rustup libgmp-dev libmpfr-dev libmpc-dev m4 && rm -fr /var/cache/apt/* /var/lib/apt/lists/*
 RUN pip3 install --break-system-packages cryptography requests pyasn1
 
 RUN GO_VERSION=$(wget -qO- https://go.dev/VERSION?m=text | head -n 1) && wget https://go.dev/dl/${GO_VERSION}.linux-amd64.tar.gz && rm -rf /usr/local/go && tar -C /usr/local -xzf ${GO_VERSION}.linux-amd64.tar.gz && rm -rf ${GO_VERSION}.linux-amd64.tar.gz


### PR DESCRIPTION
well well well, I did not test the Rust build inside the labwork docker container, but my (currently failing) pipeline did.

The package `m4` is always required by `rug` to build the Rust to C bindings.
The other precompiled  libs can be used to prevent enormous build times in the container:
Each student using Rust needs to add the feature `use-system-libs` for the currently used version of `rug` to their own `Cargo.toml`:
```toml
gmp-mpfr-sys = { version = "1.6.8", features = ["use-system-libs"] }
```