### PR TITLE
Add Python module 'gmpy2' for faster huge integer arithmetic

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN useradd -m -s /bin/bash kartfire
 
 RUN apt-get update && apt-get install --yes curl wget zip git build-essential pkg-config libcjson-dev openjdk-21-jdk libbcprov-java libgoogle-gson-java libguava-java libssl-dev gcc g++ libbotan-2-dev nlohmann-json3-dev libgmp-dev python3 python3-pip iputils-ping telnet wget rustup libgmp-dev libmpfr-dev libmpc-dev m4 && rm -fr /var/cache/apt/* /var/lib/apt/lists/*
-RUN pip3 install --break-system-packages cryptography requests pyasn1
+RUN pip3 install --break-system-packages cryptography requests pyasn1 gmpy2
 
 RUN GO_VERSION=$(wget -qO- https://go.dev/VERSION?m=text | head -n 1) && wget https://go.dev/dl/${GO_VERSION}.linux-amd64.tar.gz && rm -rf /usr/local/go && tar -C /usr/local -xzf ${GO_VERSION}.linux-amd64.tar.gz && rm -rf ${GO_VERSION}.linux-amd64.tar.gz
 ENV PATH=$PATH:/usr/local/go/bin


### PR DESCRIPTION
The container already includes GMP libraries for C and Rust. For Python to achive comparable speeds on rsa_factor it also requires GMP. 'gmpy2' is a well-maintained, commonly-used Python module for this.